### PR TITLE
Correct the S3 path for module .zip files

### DIFF
--- a/internal/module/services/storage.go
+++ b/internal/module/services/storage.go
@@ -67,7 +67,7 @@ func (s *StorageService) UploadSourceZip(server Storage_UploadSourceZipServer) e
 		req, err := server.Recv()
 
 		if filename == "" && req != nil {
-			filename = fmt.Sprintf("%s_%s.zip", req.Module.GetName(), req.Module.GetVersion())
+			filename = fmt.Sprintf("%s/%s.zip", req.Module.GetName(), req.Module.GetVersion())
 		}
 
 		if err == io.EOF {
@@ -101,7 +101,7 @@ func (s *StorageService) UploadSourceZip(server Storage_UploadSourceZipServer) e
 // Download Source Zip from storage
 func (s *StorageService) DownloadSourceZip(request *terrarium.DownloadSourceZipRequest, server Storage_DownloadSourceZipServer) error {
 	log.Println("Downloading source zip.")
-	filename := fmt.Sprintf("%s_%s.zip", request.GetModule().Name, request.Module.GetVersion())
+	filename := fmt.Sprintf("%s/%s.zip", request.GetModule().Name, request.Module.GetVersion())
 
 	in := &s3.GetObjectInput{
 		Bucket: aws.String(BucketName),


### PR DESCRIPTION
Currently modules are upload to a path in S3 like the following: &lt;Org&gt;/&lt;Module Name&gt;/&lt;provider&gt;_&lt;version&gt;.zip

We should upload the the files to a path like the following: &lt;Org&gt;/&lt;Module Name&gt;/&lt;provider&gt;/&lt;version&gt;.zip