### PR TITLE
[CIEDEV-958] Improving Version Sorting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terrariumcloud/terrarium
 go 1.18
 
 require (
+	github.com/apparentlymart/go-versions v1.0.2
 	github.com/aws/aws-sdk-go-v2 v1.17.3
 	github.com/aws/aws-sdk-go-v2/config v1.18.8
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.8

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apparentlymart/go-versions v1.0.2 h1:n5Gg9YvSLK8Zzpy743J7abh2jt7z7ammOQ0oTd/5oA4=
+github.com/apparentlymart/go-versions v1.0.2/go.mod h1:YF5j7IQtrOAOnsGkniupEA5bfCjzd7i14yu0shZavyM=
 github.com/aws/aws-sdk-go-v2 v1.17.2/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.3 h1:shN7NlnVzvDUgPQ+1rLMSxY8OWRNDRYtiqe0p/PgrhY=
 github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
@@ -127,6 +129,8 @@ github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
+github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
@@ -207,6 +211,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -237,8 +237,16 @@ func (s *VersionManagerService) ListModuleVersions(ctx context.Context, request 
 		}
 	}
 	var semverList versions.List
+	var invalidSemVersions []string
 	for _, moduleVersion := range grpcResponse.Versions {
-		semverList = append(semverList, versions.MustParseVersion(moduleVersion))
+		parsedVersion, err := versions.ParseVersion(moduleVersion)
+
+		if err != nil {
+			invalidSemVersions = append(invalidSemVersions, moduleVersion)
+		} else {
+			semverList = append(semverList, parsedVersion)
+		}
+
 	}
 	semverList.Sort()
 
@@ -246,7 +254,7 @@ func (s *VersionManagerService) ListModuleVersions(ctx context.Context, request 
 	for _, moduleVersion := range semverList {
 		sortedVersions = append(sortedVersions, moduleVersion.String())
 	}
-	grpcResponse.Versions = sortedVersions
+	grpcResponse.Versions = append(sortedVersions, invalidSemVersions...)
 
 	return &grpcResponse, nil
 }

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
@@ -235,6 +236,18 @@ func (s *VersionManagerService) ListModuleVersions(ctx context.Context, request 
 			grpcResponse.Versions = append(grpcResponse.Versions, moduleVersion.Version)
 		}
 	}
+	var semverList versions.List
+	for _, moduleVersion := range grpcResponse.Versions {
+		semverList = append(semverList, versions.MustParseVersion(moduleVersion))
+	}
+	semverList.Sort()
+
+	var sortedVersions []string
+	for _, moduleVersion := range semverList {
+		sortedVersions = append(sortedVersions, moduleVersion.String())
+	}
+	grpcResponse.Versions = sortedVersions
+
 	return &grpcResponse, nil
 }
 

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -2,24 +2,24 @@ package version_manager
 
 import (
 	"context"
-	"log"
 	"time"
+	"log"
 
-	"github.com/terrariumcloud/terrarium/internal/module/services"
-
-	"github.com/terrariumcloud/terrarium/internal/storage"
 	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+	"github.com/terrariumcloud/terrarium/internal/storage"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc"
 
-	"github.com/apparentlymart/go-versions/versions"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/apparentlymart/go-versions/versions"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -2,23 +2,23 @@ package version_manager
 
 import (
 	"context"
-	"time"
 	"log"
+	"time"
 
-	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"github.com/terrariumcloud/terrarium/internal/module/services"
 	"github.com/terrariumcloud/terrarium/internal/storage"
+	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 
-	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/apparentlymart/go-versions/versions"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/apparentlymart/go-versions/versions"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -243,9 +243,7 @@ func (s *VersionManagerService) ListModuleVersions(ctx context.Context, request 
 		if err != nil {
 			log.Printf("Skipping invalid semantic version: %v", moduleVersion)
 		} else {
-			if (parsedVersion.GreaterThan(versions.MustParseVersion("0.0.0"))) {
-				semverList = append(semverList, parsedVersion)
-			}
+			semverList = append(semverList, parsedVersion)
 		}
 
 	}

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -237,14 +237,15 @@ func (s *VersionManagerService) ListModuleVersions(ctx context.Context, request 
 		}
 	}
 	var semverList versions.List
-	var invalidSemVersions []string
 	for _, moduleVersion := range grpcResponse.Versions {
 		parsedVersion, err := versions.ParseVersion(moduleVersion)
 
 		if err != nil {
-			invalidSemVersions = append(invalidSemVersions, moduleVersion)
+			log.Printf("Skipping invalid semantic version: %v", moduleVersion)
 		} else {
-			semverList = append(semverList, parsedVersion)
+			if (parsedVersion.GreaterThan(versions.MustParseVersion("0.0.0"))) {
+				semverList = append(semverList, parsedVersion)
+			}
 		}
 
 	}
@@ -254,7 +255,7 @@ func (s *VersionManagerService) ListModuleVersions(ctx context.Context, request 
 	for _, moduleVersion := range semverList {
 		sortedVersions = append(sortedVersions, moduleVersion.String())
 	}
-	grpcResponse.Versions = append(sortedVersions, invalidSemVersions...)
+	grpcResponse.Versions = sortedVersions
 
 	return &grpcResponse, nil
 }

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -1,13 +1,13 @@
 package version_manager
 
 import (
-	"testing"
 	"context"
 	"errors"
+	"testing"
 
-	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"github.com/terrariumcloud/terrarium/internal/module/services"
 	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
+	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"google.golang.org/grpc"
 )
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -1,13 +1,13 @@
 package version_manager
 
 import (
+	"testing"
 	"context"
 	"errors"
-	"testing"
 
+	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"github.com/terrariumcloud/terrarium/internal/module/services"
 	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
-	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"google.golang.org/grpc"
 )
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -286,17 +286,23 @@ func Test_ListModuleVersions(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
-		if res.Versions[0] != "1.0.1" {
-			t.Errorf("Expected version 1.0.1, got %v", res.Versions[0])
+		if res.Versions[0] != "0.0.0-alpha" {
+			t.Errorf("Expected version 0.0.0-alpha, got %v", res.Versions[0])
 		}
-		if res.Versions[1] != "1.0.2-alpha" {
-			t.Errorf("Expected version 1.0.2-alpha, got %v", res.Versions[1])
+		if res.Versions[1] != "0.0.0" {
+			t.Errorf("Expected version 0.0.0, got %v", res.Versions[1])
 		}
-		if res.Versions[2] != "1.0.2-beta" {
-			t.Errorf("Expected version 1.0.2-beta, got %v", res.Versions[2])
+		if res.Versions[2] != "1.0.1" {
+			t.Errorf("Expected version 1.0.1, got %v", res.Versions[2])
 		}
-		if res.Versions[3] != "1.0.10" {
-			t.Errorf("Expected version 1.0.10, got %v", res.Versions[3])
+		if res.Versions[3] != "1.0.2-alpha" {
+			t.Errorf("Expected version 1.0.2-alpha, got %v", res.Versions[3])
+		}
+		if res.Versions[4] != "1.0.2-beta" {
+			t.Errorf("Expected version 1.0.2-beta, got %v", res.Versions[4])
+		}
+		if res.Versions[5] != "1.0.10" {
+			t.Errorf("Expected version 1.0.10, got %v", res.Versions[5])
 		}
 
 	})

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -286,24 +286,17 @@ func Test_ListModuleVersions(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
-		if res.Versions[0] != "0.0.0-alpha" {
-			t.Errorf("Expected version 0.0.0-alpha, got %v", res.Versions[0])
-		}
-		if res.Versions[1] != "0.0.0" {
-			t.Errorf("Expected version 0.0.0, got %v", res.Versions[1])
-		}
-		if res.Versions[2] != "1.0.1" {
-			t.Errorf("Expected version 1.0.1, got %v", res.Versions[2])
-		}
-		if res.Versions[3] != "1.0.2-alpha" {
-			t.Errorf("Expected version 1.0.2-alpha, got %v", res.Versions[3])
-		}
-		if res.Versions[4] != "1.0.2-beta" {
-			t.Errorf("Expected version 1.0.2-beta, got %v", res.Versions[4])
-		}
-		if res.Versions[5] != "1.0.10" {
-			t.Errorf("Expected version 1.0.10, got %v", res.Versions[5])
-		}
+                expectedVersions = []string {
+                "0.0.0-alpha",
+                "0.0.0",
+                "1.0.1",
+                "1.0.2-alpha",
+                "1.0.2-beta",
+                "1.0.10",                
+                }
+                if !reflect.DeepEqual(res.Versions, expectedVersions) {
+                    t.Errorf("Versions do not match, got %v, want %v", res.Versions, expectedVersions)
+                }
 
 	})
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -255,8 +255,23 @@ func Test_ListModuleVersions(t *testing.T) {
 		req := services.ListModuleVersionsRequest{Module: "dummy"}
 		res, err := svc.ListModuleVersions(context.TODO(), &req)
 
-		if err == nil {
-			t.Errorf("Expected no error, got %v", res)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if res.Versions[0] != "1.0.1" {
+			t.Errorf("Expected version 1.0.1, got %v", res.Versions[0])
+		}
+		if res.Versions[1] != "1.0.2-alpha" {
+			t.Errorf("Expected version 1.0.2-alpha, got %v", res.Versions[1])
+		}
+		if res.Versions[2] != "1.0.2-beta" {
+			t.Errorf("Expected version 1.0.2-beta, got %v", res.Versions[2])
+		}
+		if res.Versions[3] != "1.0.10" {
+			t.Errorf("Expected version 1.0.10, got %v", res.Versions[3])
+		}
+		if res.Versions[4] != "v1.0.2-gamma" {
+			t.Errorf("Expected version v1.0.2-gamma, got %v", res.Versions[4])
 		}
 
 	})

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -3,6 +3,7 @@ package version_manager
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -286,17 +287,17 @@ func Test_ListModuleVersions(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
-                expectedVersions = []string {
-                "0.0.0-alpha",
-                "0.0.0",
-                "1.0.1",
-                "1.0.2-alpha",
-                "1.0.2-beta",
-                "1.0.10",                
-                }
-                if !reflect.DeepEqual(res.Versions, expectedVersions) {
-                    t.Errorf("Versions do not match, got %v, want %v", res.Versions, expectedVersions)
-                }
+		expectedVersions := []string{
+			"0.0.0-alpha",
+			"0.0.0",
+			"1.0.1",
+			"1.0.2-alpha",
+			"1.0.2-beta",
+			"1.0.10",
+		}
+		if !reflect.DeepEqual(res.Versions, expectedVersions) {
+			t.Errorf("Versions do not match, got %v, want %v", res.Versions, expectedVersions)
+		}
 
 	})
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -3,10 +3,10 @@ package version_manager
 import (
 	"context"
 	"errors"
-	"github.com/terrariumcloud/terrarium/internal/module/services"
-	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
 	"testing"
 
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
 	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"google.golang.org/grpc"
 )
@@ -239,4 +239,26 @@ func Test_PublishVersion(t *testing.T) {
 			t.Errorf("Expected %v, got %v.", PublishModuleVersionError, err)
 		}
 	})
+}
+
+// Test_ListModuleVersions checks:
+// - if correct response is returned when versions are fetched
+// - if error is returned when PutItem fails
+func Test_ListModuleVersions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Listing versions", func(t *testing.T) {
+		db := &mocks.DynamoDB{}
+
+		svc := &VersionManagerService{Db: db}
+
+		req := services.ListModuleVersionsRequest{Module: "dummy"}
+		res, err := svc.ListModuleVersions(context.TODO(), &req)
+
+		if err == nil {
+			t.Errorf("Expected no error, got %v", res)
+		}
+
+	})
+
 }

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -269,9 +269,6 @@ func Test_ListModuleVersions(t *testing.T) {
 		if res.Versions[3] != "1.0.10" {
 			t.Errorf("Expected version 1.0.10, got %v", res.Versions[3])
 		}
-		if res.Versions[4] != "v1.0.2-gamma" {
-			t.Errorf("Expected version v1.0.2-gamma, got %v", res.Versions[4])
-		}
 
 	})
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/terrariumcloud/terrarium/internal/module/services"
 	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
 	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
+
 	"google.golang.org/grpc"
 )
 
@@ -247,7 +250,33 @@ func Test_ListModuleVersions(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Listing versions", func(t *testing.T) {
-		db := &mocks.DynamoDB{}
+		db := &mocks.DynamoDB{
+			ScanOut: &dynamodb.ScanOutput{
+				Items: []map[string]types.AttributeValue{
+					{
+						"Version": &types.AttributeValueMemberS{Value: "1.0.1"},
+					},
+					{
+						"Version": &types.AttributeValueMemberS{Value: "1.0.10"},
+					},
+					{
+						"Version": &types.AttributeValueMemberS{Value: "1.0.2-beta"},
+					},
+					{
+						"Version": &types.AttributeValueMemberS{Value: "1.0.2-alpha"},
+					},
+					{
+						"Version": &types.AttributeValueMemberS{Value: "v1.0.2-gamma"},
+					},
+					{
+						"Version": &types.AttributeValueMemberS{Value: "0.0.0"},
+					},
+					{
+						"Version": &types.AttributeValueMemberS{Value: "0.0.0-alpha"},
+					},
+				},
+			},
+		}
 
 		svc := &VersionManagerService{Db: db}
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -243,7 +243,6 @@ func Test_PublishVersion(t *testing.T) {
 
 // Test_ListModuleVersions checks:
 // - if correct response is returned when versions are fetched
-// - if error is returned when PutItem fails
 func Test_ListModuleVersions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/mocks/mock_dynamodb.go
+++ b/internal/storage/mocks/mock_dynamodb.go
@@ -99,7 +99,13 @@ func (mdb *DynamoDB) Scan(ctx context.Context, in *dynamodb.ScanInput, optFns ..
 				"Version": &types.AttributeValueMemberS{Value: "1.0.10"},
 			},
 			{
-				"Version": &types.AttributeValueMemberS{Value: "1.0.2"},
+				"Version": &types.AttributeValueMemberS{Value: "1.0.2-beta"},
+			},
+			{
+				"Version": &types.AttributeValueMemberS{Value: "1.0.2-alpha"},
+			},
+			{
+				"Version": &types.AttributeValueMemberS{Value: "v1.0.2-gamma"},
 			},
 		},
 	}

--- a/internal/storage/mocks/mock_dynamodb.go
+++ b/internal/storage/mocks/mock_dynamodb.go
@@ -3,7 +3,6 @@ package mocks
 import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 type DynamoDB struct {
@@ -89,32 +88,6 @@ func (mdb *DynamoDB) Scan(ctx context.Context, in *dynamodb.ScanInput, optFns ..
 
 	mdb.ScanItemInvocations++
 	mdb.TableName = *in.TableName
-
-	mdb.ScanOut = &dynamodb.ScanOutput{
-		Items: []map[string]types.AttributeValue{
-			{
-				"Version": &types.AttributeValueMemberS{Value: "1.0.1"},
-			},
-			{
-				"Version": &types.AttributeValueMemberS{Value: "1.0.10"},
-			},
-			{
-				"Version": &types.AttributeValueMemberS{Value: "1.0.2-beta"},
-			},
-			{
-				"Version": &types.AttributeValueMemberS{Value: "1.0.2-alpha"},
-			},
-			{
-				"Version": &types.AttributeValueMemberS{Value: "v1.0.2-gamma"},
-			},
-			{
-				"Version": &types.AttributeValueMemberS{Value: "0.0.0"},
-			},
-			{
-				"Version": &types.AttributeValueMemberS{Value: "0.0.0-alpha"},
-			},
-		},
-	}
 
 	return mdb.ScanOut, mdb.ScanError
 }

--- a/internal/storage/mocks/mock_dynamodb.go
+++ b/internal/storage/mocks/mock_dynamodb.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 type DynamoDB struct {
@@ -26,6 +27,9 @@ type DynamoDB struct {
 	DeleteItemInvocations    int
 	DeleteItemOut            *dynamodb.DeleteItemOutput
 	DeleteItemError          error
+	ScanItemInvocations      int
+	ScanOut                  *dynamodb.ScanOutput
+	ScanError                error
 }
 
 func (mdb *DynamoDB) DescribeTable(_ context.Context, in *dynamodb.DescribeTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
@@ -81,6 +85,24 @@ func (mdb *DynamoDB) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput,
 	return mdb.DeleteItemOut, mdb.DeleteItemError
 }
 
-func (mdb *DynamoDB) Scan(_ context.Context, in *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
-	panic("Not implemented")
+func (mdb *DynamoDB) Scan(ctx context.Context, in *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+
+	mdb.ScanItemInvocations++
+	mdb.TableName = *in.TableName
+
+	mdb.ScanOut = &dynamodb.ScanOutput{
+		Items: []map[string]types.AttributeValue{
+			{
+				"Version": &types.AttributeValueMemberS{Value: "1.0.1"},
+			},
+			{
+				"Version": &types.AttributeValueMemberS{Value: "1.0.10"},
+			},
+			{
+				"Version": &types.AttributeValueMemberS{Value: "1.0.2"},
+			},
+		},
+	}
+
+	return mdb.ScanOut, mdb.ScanError
 }

--- a/internal/storage/mocks/mock_dynamodb.go
+++ b/internal/storage/mocks/mock_dynamodb.go
@@ -107,6 +107,12 @@ func (mdb *DynamoDB) Scan(ctx context.Context, in *dynamodb.ScanInput, optFns ..
 			{
 				"Version": &types.AttributeValueMemberS{Value: "v1.0.2-gamma"},
 			},
+			{
+				"Version": &types.AttributeValueMemberS{Value: "0.0.0"},
+			},
+			{
+				"Version": &types.AttributeValueMemberS{Value: "0.0.0-alpha"},
+			},
 		},
 	}
 


### PR DESCRIPTION
- All valid semantic version inputs will be sorted and stacked at the beginning of the output list, skipping any invalid semantic versions and developmental versions.
- Added Testcase to validate sort output.

---
For a given input of semvers:

```bash
1.0.1, 1.0.10, 1.0.2-beta, 1.0.2-alpha, v1.0.2-gamma, 0.0.0, 0.0.0-alpha
```

The output of the `ListModuleVersions`  function will be:

```bash
 0.0.0-alpha, 0.0.0, 1.0.1, 1.0.2-alpha, 1.0.2-beta, 1.0.10
```
