### PR TITLE
[CIEDEV-2455] Appending Maturity field to the Browse API response

### DIFF
--- a/internal/restapi/browse/helpers.go
+++ b/internal/restapi/browse/helpers.go
@@ -33,6 +33,7 @@ func createModuleMetadataResponse(moduleMetadata *services.ModuleMetadata, modul
 		Provider:     moduleMetadata.Provider,
 		Description:  moduleMetadata.Description,
 		SourceUrl:    moduleMetadata.SourceUrl,
+		Maturity:     moduleMetadata.Maturity.String(),
 		Versions:     moduleVersions,
 	}
 }

--- a/internal/restapi/browse/helpers_test.go
+++ b/internal/restapi/browse/helpers_test.go
@@ -22,7 +22,7 @@ func Test_createModuleMetadataResponse(t *testing.T) {
 			args: args{
 				moduleMetadata: &services.ModuleMetadata{
 					Organization: "cie",
-					Name:      	  "test-module",
+					Name:         "test-module",
 					Provider:     "aws",
 					Description:  "This is the description for the module it is supposedly a long text",
 					SourceUrl:    "https://github.com/...",
@@ -35,7 +35,7 @@ func Test_createModuleMetadataResponse(t *testing.T) {
 			},
 			want: &moduleItem{
 				Organization: "cie",
-				Name:      	  "test-module",
+				Name:         "test-module",
 				Provider:     "aws",
 				Description:  "This is the description for the module it is supposedly a long text",
 				SourceUrl:    "https://github.com/...",

--- a/internal/restapi/browse/helpers_test.go
+++ b/internal/restapi/browse/helpers_test.go
@@ -1,0 +1,57 @@
+package browse
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+)
+
+func Test_createModuleMetadataResponse(t *testing.T) {
+	type args struct {
+		moduleMetadata *services.ModuleMetadata
+		moduleVersions []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *moduleItem
+	}{
+		{
+			name: "Module Metadata Reponse",
+			args: args{
+				moduleMetadata: &services.ModuleMetadata{
+					Organization: "cie",
+					Name:      	  "test-module",
+					Provider:     "aws",
+					Description:  "This is the description for the module it is supposedly a long text",
+					SourceUrl:    "https://github.com/...",
+					Maturity:     6,
+				},
+				moduleVersions: []string{
+					"1.0.1",
+					"1.0.2",
+				},
+			},
+			want: &moduleItem{
+				Organization: "cie",
+				Name:      	  "test-module",
+				Provider:     "aws",
+				Description:  "This is the description for the module it is supposedly a long text",
+				SourceUrl:    "https://github.com/...",
+				Maturity:     "DEPRECATED",
+				Versions: []string{
+					"1.0.1",
+					"1.0.2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createModuleMetadataResponse(tt.args.moduleMetadata, tt.args.moduleVersions); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("createModuleMetadataResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/restapi/browse/helpers_test.go
+++ b/internal/restapi/browse/helpers_test.go
@@ -18,7 +18,7 @@ func Test_createModuleMetadataResponse(t *testing.T) {
 		want *moduleItem
 	}{
 		{
-			name: "Module Metadata Reponse",
+			name: "Module Metadata Response",
 			args: args{
 				moduleMetadata: &services.ModuleMetadata{
 					Organization: "cie",


### PR DESCRIPTION
- Updated Browse API's  Module metadata response to include Module's Maturity.
- Added Test Case
![image](https://github.com/terrariumcloud/terrarium/assets/48598449/ec743ec2-df39-4f97-9c80-13183de8bf77)
