### PR TITLE
update semconv package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	noop "go.opentelemetry.io/otel/trace"
 
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Update package which is imported with specific version inside root go. This was left to the old version after all the other packages were updated in gomod file to 1.19. 

semconv package broke the initializing of the traceExporter objects with this error:

The SchemaURL of the resources is not merged.