### PR TITLE
Change serviceResource definition

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,27 +75,19 @@ func newTraceExporter(ctx context.Context) (*otlptrace.Exporter, error) {
 }
 
 func newServiceResource(name string) *resource.Resource {
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String(name)),
-	)
-	if err != nil {
-		log.Fatalf("The SchemaURL of the resources is not merged.")
-	}
 	versionInfo := buildVersion
 	if serviceVersion, found := os.LookupEnv("OTEL_SERVICE_VERSION"); found {
 		log.Println("Warning: build time version overriden by environment variable")
 		versionInfo = serviceVersion
 
 	}
-	res, err = resource.Merge(
-		res,
-		resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceVersionKey.String(versionInfo)),
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceName(name), semconv.ServiceVersion(versionInfo)),
 	)
 	if err != nil {
 		log.Fatalf("The SchemaURL of the resources is not merged.")
-	}
-
+	}	
 	return res
 }
 


### PR DESCRIPTION
Changed service resource definition to match the new way to initialize Merging: 
https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/stdout/stdouttrace/example_test.go#L57-L63
