### PR TITLE
CIEDEV-2144: Expand Version Manager service to enable publishing of releases

### DIFF
--- a/cmd/version_manager.go
+++ b/cmd/version_manager.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"github.com/terrariumcloud/terrarium/internal/module/services/version_manager"
-	"github.com/terrariumcloud/terrarium/internal/storage"
-
 	"github.com/spf13/cobra"
+	"github.com/terrariumcloud/terrarium/internal/module/services/version_manager"
+	"github.com/terrariumcloud/terrarium/internal/release/services/release"
+	"github.com/terrariumcloud/terrarium/internal/storage"
 )
 
 var versionManagerCmd = &cobra.Command{
@@ -16,7 +16,9 @@ var versionManagerCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionManagerCmd)
+	rootCmd.AddCommand(releaseServiceCmd)
 	versionManagerCmd.Flags().StringVarP(&version_manager.VersionsTableName, "table", "t", version_manager.DefaultVersionsTableName, "Module versions table name")
+	releaseServiceCmd.Flags().StringVarP(&release.ReleaseServiceEndpoint, "release", "", release.DefaultReleaseServiceEndpoint, "GRPC Endpoint for Release Service")
 }
 
 func runVersionManager(cmd *cobra.Command, args []string) {

--- a/cmd/version_manager.go
+++ b/cmd/version_manager.go
@@ -24,9 +24,10 @@ func init() {
 func runVersionManager(cmd *cobra.Command, args []string) {
 
 	versionManagerServer := &version_manager.VersionManagerService{
-		Db:     storage.NewDynamoDbClient(awsAccessKey, awsSecretKey, awsRegion),
-		Table:  version_manager.VersionsTableName,
-		Schema: version_manager.GetModuleVersionsSchema(version_manager.VersionsTableName),
+		Db:                     storage.NewDynamoDbClient(awsAccessKey, awsSecretKey, awsRegion),
+		Table:                  version_manager.VersionsTableName,
+		Schema:                 version_manager.GetModuleVersionsSchema(version_manager.VersionsTableName),
+		ReleaseServiceEndpoint: release.ReleaseServiceEndpoint,
 	}
 
 	startGRPCService("version-manager", versionManagerServer)

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -206,7 +206,7 @@ func (s *VersionManagerService) PublishVersion(ctx context.Context, request *ser
 		return nil, err
 	}
 
-	if parsedVersion.GreaterThan(DevelopmentVersion) {
+	if parsedVersion.GreaterThan(DevelopmentVersion) && s.ReleaseServiceEndpoint != "" {
 		moduleAddress := strings.Split(request.Module.GetName(), "/")
 		orgName := moduleAddress[0]
 

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -210,7 +210,6 @@ func (s *VersionManagerService) PublishVersion(ctx context.Context, request *ser
 		moduleAddress := strings.Split(request.Module.GetName(), "/")
 		orgName := moduleAddress[0]
 
-		
 		if connVersion, err := services.CreateGRPCConnection(s.ReleaseServiceEndpoint); err != nil {
 			span.RecordError(err)
 			log.Printf("Failed to connect to '%s': %v", s.ReleaseServiceEndpoint, err)

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -71,6 +71,7 @@ func (s *VersionManagerService) RegisterWithServer(grpcServer grpc.ServiceRegist
 		return ModuleVersionsTableInitializationError
 	}
 	services.RegisterVersionManagerServer(grpcServer, s)
+
 	return nil
 }
 
@@ -225,7 +226,7 @@ func (s *VersionManagerService) PublishVersion(ctx context.Context, request *ser
 		})
 
 		if err1 != nil {
-			log.Printf("Failed to publish release: %v", err)
+			span.RecordError(err)
 			return nil, PublishReleaseVersionError
 		}
 	}
@@ -319,5 +320,12 @@ func GetModuleVersionsSchema(table string) *dynamodb.CreateTableInput {
 		},
 		TableName:   aws.String(table),
 		BillingMode: types.BillingModePayPerRequest,
+	}
+}
+
+func closeClient(conn *grpc.ClientConn) {
+	err := conn.Close()
+	if err != nil {
+
 	}
 }

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -322,8 +322,5 @@ func GetModuleVersionsSchema(table string) *dynamodb.CreateTableInput {
 }
 
 func closeClient(conn *grpc.ClientConn) {
-	err := conn.Close()
-	if err != nil {
-
-	}
+	_ = conn.Close()
 }

--- a/internal/module/services/version_manager/version_manager.go
+++ b/internal/module/services/version_manager/version_manager.go
@@ -45,7 +45,6 @@ var (
 	CreateModuleVersionError               = status.Error(codes.Unknown, "Failed to create module version.")
 	AbortModuleVersionError                = status.Error(codes.Unknown, "Failed to abort module version.")
 	PublishModuleVersionError              = status.Error(codes.Unknown, "Failed to publish module version.")
-	PublishReleaseVersionError             = status.Error(codes.Unknown, "Failed to publish release version.")
 	DevelopmentVersion                     = versions.MustParseVersion("0.0.0")
 )
 

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/terrariumcloud/terrarium/internal/module/services"
-	"github.com/terrariumcloud/terrarium/internal/release/services/release"
 	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
 	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 
@@ -73,7 +72,7 @@ func Test_RegisterVersionManagerWithServer(t *testing.T) {
 func Test_BeginVersion(t *testing.T) {
 	t.Parallel()
 
-	t.Run("when new official version is created", func(t *testing.T) {
+	t.Run("when new version is created", func(t *testing.T) {
 		db := &mocks.DynamoDB{}
 
 		svc := &VersionManagerService{Db: db}
@@ -86,34 +85,8 @@ func Test_BeginVersion(t *testing.T) {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if db.PutItemInvocations != 2 {
-			t.Errorf("Expected 2 call to PutItem, got %v", db.PutItemInvocations)
-		}
-
-		if db.TableName != release.ReleaseTableName {
-			t.Errorf("Expected tableName to be %v, got %v.", VersionsTableName, db.TableName)
-		}
-
-		if res != VersionCreated {
-			t.Errorf("Expected %v, got %v.", VersionCreated, res)
-		}
-	})
-
-	t.Run("when new development version is created", func(t *testing.T) {
-		db := &mocks.DynamoDB{}
-
-		svc := &VersionManagerService{Db: db}
-
-		req := &terrarium.BeginVersionRequest{Module: &terrarium.Module{Name: "test", Version: "v0.0.0-dev"}}
-
-		res, err := svc.BeginVersion(context.TODO(), req)
-
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-
 		if db.PutItemInvocations != 1 {
-			t.Errorf("Expected 2 call to PutItem, got %v", db.PutItemInvocations)
+			t.Errorf("Expected 1 call to PutItem, got %v", db.PutItemInvocations)
 		}
 
 		if db.TableName != VersionsTableName {

--- a/internal/module/services/version_manager/version_manager_test.go
+++ b/internal/module/services/version_manager/version_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/terrariumcloud/terrarium/internal/module/services"
+	"github.com/terrariumcloud/terrarium/internal/release/services/release"
 	"github.com/terrariumcloud/terrarium/internal/storage/mocks"
 	terrarium "github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 
@@ -76,6 +77,12 @@ func Test_BeginVersion(t *testing.T) {
 		db := &mocks.DynamoDB{}
 
 		svc := &VersionManagerService{Db: db}
+
+		release_service := &release.ReleaseService{Db: db}
+
+		s := grpc.NewServer(*new([]grpc.ServerOption)...)
+
+		err := release_service.RegisterWithServer(s)
 
 		req := &terrarium.BeginVersionRequest{Module: &terrarium.Module{Name: "test", Version: "v1.0.0"}}
 


### PR DESCRIPTION
When the version-manager service is called, for official releases, release service publish is invoked and DB entry is created.

Unit test for official release (`Ex: v1.0.0`):
![image](https://github.com/terrariumcloud/terrarium/assets/46104369/d66adcae-fbfb-472d-9c61-16e22ccc971f)

Unit test for development release (`Ex0.0.0-dev`):
![image](https://github.com/terrariumcloud/terrarium/assets/46104369/229ec0e1-2da8-4e44-84fc-50184d5fe617)

![image](https://github.com/terrariumcloud/terrarium/assets/75800171/ecf3be0e-96a8-4806-b5fa-d3027a55b130)

