### PR TITLE
Introduce GRPC client helpers and pass *Client interfaces around

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -24,6 +24,8 @@ func init() {
 
 func runBrowseServer(cmd *cobra.Command, args []string) {
 
-	restAPIServer := browse.New()
+	restAPIServer := browse.New(registrar.NewRegistrarGrpcClient(registrar.RegistrarServiceEndpoint),
+		version_manager.NewVersionManagerGrpcClient(version_manager.VersionManagerEndpoint),
+		release.NewBrowseGrpcClient(release.ReleaseServiceEndpoint))
 	startRESTAPIService("browse", "", restAPIServer)
 }

--- a/cmd/rest_modules_v1.go
+++ b/cmd/rest_modules_v1.go
@@ -32,6 +32,7 @@ func init() {
 
 func runRESTModulesV1Server(cmd *cobra.Command, args []string) {
 
-	restAPIServer := modulesv1.New()
+	restAPIServer := modulesv1.New(version_manager.NewVersionManagerGrpcClient(version_manager.VersionManagerEndpoint), storage.NewStorageGrpcClient(storage.StorageServiceEndpoint))
+
 	startRESTAPIService("rest-modules-v1", mountPath, restAPIServer)
 }

--- a/cmd/version_manager.go
+++ b/cmd/version_manager.go
@@ -16,18 +16,17 @@ var versionManagerCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionManagerCmd)
-	rootCmd.AddCommand(releaseServiceCmd)
 	versionManagerCmd.Flags().StringVarP(&version_manager.VersionsTableName, "table", "t", version_manager.DefaultVersionsTableName, "Module versions table name")
-	releaseServiceCmd.Flags().StringVarP(&release.ReleaseServiceEndpoint, "release", "", release.DefaultReleaseServiceEndpoint, "GRPC Endpoint for Release Service")
+	versionManagerCmd.Flags().StringVarP(&release.ReleaseServiceEndpoint, "release", "", release.DefaultReleaseServiceEndpoint, "GRPC Endpoint for Release Service")
 }
 
 func runVersionManager(cmd *cobra.Command, args []string) {
 
 	versionManagerServer := &version_manager.VersionManagerService{
-		Db:                     storage.NewDynamoDbClient(awsAccessKey, awsSecretKey, awsRegion),
-		Table:                  version_manager.VersionsTableName,
-		Schema:                 version_manager.GetModuleVersionsSchema(version_manager.VersionsTableName),
-		ReleaseServiceEndpoint: release.ReleaseServiceEndpoint,
+		Db:             storage.NewDynamoDbClient(awsAccessKey, awsSecretKey, awsRegion),
+		Table:          version_manager.VersionsTableName,
+		Schema:         version_manager.GetModuleVersionsSchema(version_manager.VersionsTableName),
+		ReleaseService: release.NewPublisherGrpcClient(release.ReleaseServiceEndpoint),
 	}
 
 	startGRPCService("version-manager", versionManagerServer)

--- a/internal/module/services/registrar/client.go
+++ b/internal/module/services/registrar/client.go
@@ -16,34 +16,34 @@ func NewRegistrarGrpcClient(endpoint string) services.RegistrarClient {
 }
 
 func (r registrarGrpcClient) Register(ctx context.Context, in *module.RegisterModuleRequest, opts ...grpc.CallOption) (*module.Response, error) {
-	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(r.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewRegistrarClient(connVersion)
+		client := services.NewRegistrarClient(conn)
 		return client.Register(ctx, in, opts...)
 	}
 }
 
 func (r registrarGrpcClient) ListModules(ctx context.Context, in *services.ListModulesRequest, opts ...grpc.CallOption) (*services.ListModulesResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(r.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewRegistrarClient(connVersion)
+		client := services.NewRegistrarClient(conn)
 		return client.ListModules(ctx, in, opts...)
 	}
 }
 
 func (r registrarGrpcClient) GetModule(ctx context.Context, in *services.GetModuleRequest, opts ...grpc.CallOption) (*services.GetModuleResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(r.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewRegistrarClient(connVersion)
+		client := services.NewRegistrarClient(conn)
 		return client.GetModule(ctx, in, opts...)
 	}
 }

--- a/internal/module/services/registrar/client.go
+++ b/internal/module/services/registrar/client.go
@@ -1,0 +1,49 @@
+package registrar
+
+import (
+	"context"
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+	"github.com/terrariumcloud/terrarium/pkg/terrarium/module"
+	"google.golang.org/grpc"
+)
+
+type registrarGrpcClient struct {
+	endpoint string
+}
+
+func NewRegistrarGrpcClient(endpoint string) services.RegistrarClient {
+	return &registrarGrpcClient{endpoint: endpoint}
+}
+
+func (r registrarGrpcClient) Register(ctx context.Context, in *module.RegisterModuleRequest, opts ...grpc.CallOption) (*module.Response, error) {
+	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewRegistrarClient(connVersion)
+		return client.Register(ctx, in, opts...)
+	}
+}
+
+func (r registrarGrpcClient) ListModules(ctx context.Context, in *services.ListModulesRequest, opts ...grpc.CallOption) (*services.ListModulesResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewRegistrarClient(connVersion)
+		return client.ListModules(ctx, in, opts...)
+	}
+}
+
+func (r registrarGrpcClient) GetModule(ctx context.Context, in *services.GetModuleRequest, opts ...grpc.CallOption) (*services.GetModuleResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewRegistrarClient(connVersion)
+		return client.GetModule(ctx, in, opts...)
+	}
+}

--- a/internal/module/services/storage/client.go
+++ b/internal/module/services/storage/client.go
@@ -5,6 +5,8 @@ import (
 	"github.com/terrariumcloud/terrarium/internal/module/services"
 	"github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"io"
 )
 
 type storageGrpcClient struct {
@@ -16,23 +18,104 @@ func NewStorageGrpcClient(endpoint string) services.StorageClient {
 }
 
 func (s storageGrpcClient) UploadSourceZip(ctx context.Context, opts ...grpc.CallOption) (services.Storage_UploadSourceZipClient, error) {
-	if connVersion, err := services.CreateGRPCConnection(s.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(s.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
-
-		client := services.NewStorageClient(connVersion)
-		return client.UploadSourceZip(ctx, opts...)
+		client := services.NewStorageClient(conn)
+		if upload, err := client.UploadSourceZip(ctx, opts...); err == nil {
+			return &uploadSourceZipClient{client: upload, conn: conn}, nil
+		} else {
+			_ = conn.Close()
+			return nil, err
+		}
 	}
 }
 
 func (s storageGrpcClient) DownloadSourceZip(ctx context.Context, in *module.DownloadSourceZipRequest, opts ...grpc.CallOption) (services.Storage_DownloadSourceZipClient, error) {
-	if connVersion, err := services.CreateGRPCConnection(s.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(s.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
-
-		client := services.NewStorageClient(connVersion)
-		return client.DownloadSourceZip(ctx, in, opts...)
+		client := services.NewStorageClient(conn)
+		if download, err := client.DownloadSourceZip(ctx, in, opts...); err == nil {
+			return &downloadSourceZipClient{conn: conn, client: download}, nil
+		} else {
+			_ = conn.Close()
+			return nil, err
+		}
 	}
+}
+
+type uploadSourceZipClient struct {
+	conn   *grpc.ClientConn
+	client services.Storage_UploadSourceZipClient
+}
+
+func (u *uploadSourceZipClient) Send(request *module.UploadSourceZipRequest) error {
+	return u.client.Send(request)
+}
+
+func (u *uploadSourceZipClient) CloseAndRecv() (*module.Response, error) {
+	defer func() { _ = u.conn.Close() }()
+	return u.client.CloseAndRecv()
+}
+
+func (u *uploadSourceZipClient) Header() (metadata.MD, error) {
+	return u.client.Header()
+}
+
+func (u *uploadSourceZipClient) Trailer() metadata.MD {
+	return u.client.Trailer()
+}
+
+func (u *uploadSourceZipClient) CloseSend() error {
+	return u.client.CloseSend()
+}
+
+func (u *uploadSourceZipClient) Context() context.Context {
+	return u.client.Context()
+}
+
+func (u *uploadSourceZipClient) SendMsg(m any) error {
+	return u.client.SendMsg(m)
+}
+
+func (u *uploadSourceZipClient) RecvMsg(m any) error {
+	return u.client.RecvMsg(m)
+}
+
+type downloadSourceZipClient struct {
+	conn   *grpc.ClientConn
+	client services.Storage_DownloadSourceZipClient
+}
+
+func (d downloadSourceZipClient) Recv() (*module.SourceZipResponse, error) {
+	result, err := d.client.Recv()
+	if err == io.EOF {
+		_ = d.conn.Close()
+	}
+	return result, err
+}
+
+func (d downloadSourceZipClient) Header() (metadata.MD, error) {
+	return d.client.Header()
+}
+
+func (d downloadSourceZipClient) Trailer() metadata.MD {
+	return d.client.Trailer()
+}
+
+func (d downloadSourceZipClient) CloseSend() error {
+	return d.client.CloseSend()
+}
+
+func (d downloadSourceZipClient) Context() context.Context {
+	return d.client.Context()
+}
+
+func (d downloadSourceZipClient) SendMsg(m any) error {
+	return d.client.SendMsg(m)
+}
+
+func (d downloadSourceZipClient) RecvMsg(m any) error {
+	return d.client.RecvMsg(m)
 }

--- a/internal/module/services/storage/client.go
+++ b/internal/module/services/storage/client.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"context"
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+	"github.com/terrariumcloud/terrarium/pkg/terrarium/module"
+	"google.golang.org/grpc"
+)
+
+type storageGrpcClient struct {
+	endpoint string
+}
+
+func NewStorageGrpcClient(endpoint string) services.StorageClient {
+	return &storageGrpcClient{endpoint: endpoint}
+}
+
+func (s storageGrpcClient) UploadSourceZip(ctx context.Context, opts ...grpc.CallOption) (services.Storage_UploadSourceZipClient, error) {
+	if connVersion, err := services.CreateGRPCConnection(s.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewStorageClient(connVersion)
+		return client.UploadSourceZip(ctx, opts...)
+	}
+}
+
+func (s storageGrpcClient) DownloadSourceZip(ctx context.Context, in *module.DownloadSourceZipRequest, opts ...grpc.CallOption) (services.Storage_DownloadSourceZipClient, error) {
+	if connVersion, err := services.CreateGRPCConnection(s.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewStorageClient(connVersion)
+		return client.DownloadSourceZip(ctx, in, opts...)
+	}
+}

--- a/internal/module/services/version_manager/client.go
+++ b/internal/module/services/version_manager/client.go
@@ -16,45 +16,45 @@ func NewVersionManagerGrpcClient(endpoint string) services.VersionManagerClient 
 }
 
 func (v versionManagerGrpcClient) BeginVersion(ctx context.Context, in *module.BeginVersionRequest, opts ...grpc.CallOption) (*module.Response, error) {
-	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(v.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewVersionManagerClient(connVersion)
+		client := services.NewVersionManagerClient(conn)
 		return client.BeginVersion(ctx, in, opts...)
 	}
 }
 
 func (v versionManagerGrpcClient) AbortVersion(ctx context.Context, in *services.TerminateVersionRequest, opts ...grpc.CallOption) (*module.Response, error) {
-	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(v.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewVersionManagerClient(connVersion)
+		client := services.NewVersionManagerClient(conn)
 		return client.AbortVersion(ctx, in, opts...)
 	}
 }
 
 func (v versionManagerGrpcClient) PublishVersion(ctx context.Context, in *services.TerminateVersionRequest, opts ...grpc.CallOption) (*module.Response, error) {
-	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(v.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewVersionManagerClient(connVersion)
+		client := services.NewVersionManagerClient(conn)
 		return client.PublishVersion(ctx, in, opts...)
 	}
 }
 
 func (v versionManagerGrpcClient) ListModuleVersions(ctx context.Context, in *services.ListModuleVersionsRequest, opts ...grpc.CallOption) (*services.ListModuleVersionsResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(v.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := services.NewVersionManagerClient(connVersion)
+		client := services.NewVersionManagerClient(conn)
 		return client.ListModuleVersions(ctx, in, opts...)
 	}
 }

--- a/internal/module/services/version_manager/client.go
+++ b/internal/module/services/version_manager/client.go
@@ -1,0 +1,60 @@
+package version_manager
+
+import (
+	"context"
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+	"github.com/terrariumcloud/terrarium/pkg/terrarium/module"
+	"google.golang.org/grpc"
+)
+
+type versionManagerGrpcClient struct {
+	endpoint string
+}
+
+func NewVersionManagerGrpcClient(endpoint string) services.VersionManagerClient {
+	return &versionManagerGrpcClient{endpoint: endpoint}
+}
+
+func (v versionManagerGrpcClient) BeginVersion(ctx context.Context, in *module.BeginVersionRequest, opts ...grpc.CallOption) (*module.Response, error) {
+	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewVersionManagerClient(connVersion)
+		return client.BeginVersion(ctx, in, opts...)
+	}
+}
+
+func (v versionManagerGrpcClient) AbortVersion(ctx context.Context, in *services.TerminateVersionRequest, opts ...grpc.CallOption) (*module.Response, error) {
+	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewVersionManagerClient(connVersion)
+		return client.AbortVersion(ctx, in, opts...)
+	}
+}
+
+func (v versionManagerGrpcClient) PublishVersion(ctx context.Context, in *services.TerminateVersionRequest, opts ...grpc.CallOption) (*module.Response, error) {
+	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewVersionManagerClient(connVersion)
+		return client.PublishVersion(ctx, in, opts...)
+	}
+}
+
+func (v versionManagerGrpcClient) ListModuleVersions(ctx context.Context, in *services.ListModuleVersionsRequest, opts ...grpc.CallOption) (*services.ListModuleVersionsResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(v.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := services.NewVersionManagerClient(connVersion)
+		return client.ListModuleVersions(ctx, in, opts...)
+	}
+}

--- a/internal/release/services/release/client.go
+++ b/internal/release/services/release/client.go
@@ -17,34 +17,34 @@ func NewBrowseGrpcClient(endpoint string) releaseSvc.BrowseClient {
 }
 
 func (b browseGrpcClient) ListReleases(ctx context.Context, in *releaseSvc.ListReleasesRequest, opts ...grpc.CallOption) (*releaseSvc.ListReleasesResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(b.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(b.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := releaseSvc.NewBrowseClient(connVersion)
+		client := releaseSvc.NewBrowseClient(conn)
 		return client.ListReleases(ctx, in, opts...)
 	}
 }
 
 func (b browseGrpcClient) ListReleaseTypes(ctx context.Context, in *releaseSvc.ListReleaseTypesRequest, opts ...grpc.CallOption) (*releaseSvc.ListReleaseTypesResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(b.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(b.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := releaseSvc.NewBrowseClient(connVersion)
+		client := releaseSvc.NewBrowseClient(conn)
 		return client.ListReleaseTypes(ctx, in, opts...)
 	}
 }
 
 func (b browseGrpcClient) ListOrganization(ctx context.Context, in *releaseSvc.ListOrganizationRequest, opts ...grpc.CallOption) (*releaseSvc.ListOrganizationResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(b.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(b.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := releaseSvc.NewBrowseClient(connVersion)
+		client := releaseSvc.NewBrowseClient(conn)
 		return client.ListOrganization(ctx, in, opts...)
 	}
 }
@@ -58,12 +58,12 @@ func NewPublisherGrpcClient(endpoint string) releaseSvc.PublisherClient {
 }
 
 func (r publisherGrpcClient) Publish(ctx context.Context, in *release.PublishRequest, opts ...grpc.CallOption) (*release.PublishResponse, error) {
-	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+	if conn, err := services.CreateGRPCConnection(r.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = connVersion.Close() }()
+		defer func() { _ = conn.Close() }()
 
-		client := releaseSvc.NewPublisherClient(connVersion)
+		client := releaseSvc.NewPublisherClient(conn)
 		return client.Publish(ctx, in, opts...)
 	}
 }

--- a/internal/release/services/release/client.go
+++ b/internal/release/services/release/client.go
@@ -1,0 +1,69 @@
+package release
+
+import (
+	"context"
+	"github.com/terrariumcloud/terrarium/internal/module/services"
+	releaseSvc "github.com/terrariumcloud/terrarium/internal/release/services"
+	"github.com/terrariumcloud/terrarium/pkg/terrarium/release"
+	"google.golang.org/grpc"
+)
+
+type browseGrpcClient struct {
+	endpoint string
+}
+
+func NewBrowseGrpcClient(endpoint string) releaseSvc.BrowseClient {
+	return &browseGrpcClient{endpoint: endpoint}
+}
+
+func (b browseGrpcClient) ListReleases(ctx context.Context, in *releaseSvc.ListReleasesRequest, opts ...grpc.CallOption) (*releaseSvc.ListReleasesResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(b.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := releaseSvc.NewBrowseClient(connVersion)
+		return client.ListReleases(ctx, in, opts...)
+	}
+}
+
+func (b browseGrpcClient) ListReleaseTypes(ctx context.Context, in *releaseSvc.ListReleaseTypesRequest, opts ...grpc.CallOption) (*releaseSvc.ListReleaseTypesResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(b.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := releaseSvc.NewBrowseClient(connVersion)
+		return client.ListReleaseTypes(ctx, in, opts...)
+	}
+}
+
+func (b browseGrpcClient) ListOrganization(ctx context.Context, in *releaseSvc.ListOrganizationRequest, opts ...grpc.CallOption) (*releaseSvc.ListOrganizationResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(b.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := releaseSvc.NewBrowseClient(connVersion)
+		return client.ListOrganization(ctx, in, opts...)
+	}
+}
+
+type publisherGrpcClient struct {
+	endpoint string
+}
+
+func NewPublisherGrpcClient(endpoint string) releaseSvc.PublisherClient {
+	return &publisherGrpcClient{endpoint: endpoint}
+}
+
+func (r publisherGrpcClient) Publish(ctx context.Context, in *release.PublishRequest, opts ...grpc.CallOption) (*release.PublishResponse, error) {
+	if connVersion, err := services.CreateGRPCConnection(r.endpoint); err != nil {
+		return nil, err
+	} else {
+		defer func() { _ = connVersion.Close() }()
+
+		client := releaseSvc.NewPublisherClient(connVersion)
+		return client.Publish(ctx, in, opts...)
+	}
+}


### PR DESCRIPTION
Make unit testing easier by removing the Grpc code from the majority of places and instead pass around *Client interfaces.

Add GRPC Client helper functions which do the same thing we had been doing before, ie on call to an interface function create a GRPC connection, do the request and return.