### PR TITLE
Fix error when retrieve container dependencies

### DIFF
--- a/internal/module/services/dependency_manager/client.go
+++ b/internal/module/services/dependency_manager/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/terrariumcloud/terrarium/internal/module/services"
 	"github.com/terrariumcloud/terrarium/pkg/terrarium/module"
 	"google.golang.org/grpc"
+	"io"
 )
 
 type dependencyManagerGrpcClient struct {
@@ -41,10 +42,16 @@ func (d dependencyManagerGrpcClient) RetrieveContainerDependencies(ctx context.C
 	if conn, err := services.CreateGRPCConnection(d.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = conn.Close() }()
-
 		client := services.NewDependencyManagerClient(conn)
-		return client.RetrieveContainerDependencies(ctx, in, opts...)
+		if deps, err := client.RetrieveContainerDependencies(ctx, in, opts...); err == nil {
+			return &dependencyManager_RetrieveContainerDependenciesClient{
+				conn:   conn,
+				client: deps,
+			}, nil
+		} else {
+			_ = conn.Close()
+			return nil, err
+		}
 	}
 }
 
@@ -52,9 +59,43 @@ func (d dependencyManagerGrpcClient) RetrieveModuleDependencies(ctx context.Cont
 	if conn, err := services.CreateGRPCConnection(d.endpoint); err != nil {
 		return nil, err
 	} else {
-		defer func() { _ = conn.Close() }()
-
 		client := services.NewDependencyManagerClient(conn)
-		return client.RetrieveModuleDependencies(ctx, in, opts...)
+		if deps, err := client.RetrieveModuleDependencies(ctx, in, opts...); err == nil {
+			return &dependencyManager_RetrieveModuleDependenciesClient{
+				conn:   conn,
+				client: deps,
+			}, nil
+		} else {
+			_ = conn.Close()
+			return nil, err
+		}
 	}
+}
+
+type dependencyManager_RetrieveContainerDependenciesClient struct {
+	grpc.ClientStream
+	conn   *grpc.ClientConn
+	client services.DependencyManager_RetrieveContainerDependenciesClient
+}
+
+func (d *dependencyManager_RetrieveContainerDependenciesClient) Recv() (*module.ContainerDependenciesResponseV2, error) {
+	result, err := d.client.Recv()
+	if err == io.EOF {
+		_ = d.conn.Close()
+	}
+	return result, err
+}
+
+type dependencyManager_RetrieveModuleDependenciesClient struct {
+	grpc.ClientStream
+	conn   *grpc.ClientConn
+	client services.DependencyManager_RetrieveModuleDependenciesClient
+}
+
+func (d dependencyManager_RetrieveModuleDependenciesClient) Recv() (*module.ModuleDependenciesResponse, error) {
+	result, err := d.client.Recv()
+	if err == io.EOF {
+		_ = d.conn.Close()
+	}
+	return result, err
 }


### PR DESCRIPTION
The following error "rpc error: code = Canceled desc = grpc: the client connection is closing" was caused by the closing the GRPC client connection before the stream response had been used.

Fix this by only closing the connection when we hit an io.EOF error in the Recv() function.

Tested using an in progress cli utility which confirmed it's now working.