### PR TITLE
[Terrarium - Providers]: Fix empty structs

### DIFF
--- a/internal/provider/services/version_manager/version_manager.go
+++ b/internal/provider/services/version_manager/version_manager.go
@@ -57,16 +57,16 @@ type VersionManagerService struct {
 }
 
 type Provider struct {
-	Name          string                    `json:"name" bson:"name" dynamodbav:"name"`
-	Version       string                    `json:"version" bson:"version" dynamodbav:"version"`
-	Protocols     []string                  `json:"protocols" bson:"protocols" dynamodbav:"protocols"`
-	Platforms     []*terrarium.PlatformItem `json:"platforms" bson:"platforms" dynamodbav:"platforms"`
-	Description   string                    `json:"description" bson:"description" dynamodbav:"description"`
-	SourceRepoUrl string                    `json:"source_repo_url" bson:"source_repo_url" dynamodbav:"source_repo_url"`
-	Maturity      string                    `json:"maturity" bson:"maturity" dynamodbav:"maturity"`
-	CreatedOn     string                    `json:"created_on" bson:"created_on" dynamodbav:"created_on"`
-	ModifiedOn    string                    `json:"modified_on" bson:"modified_on" dynamodbav:"modified_on"`
-	PublishedOn   string                    `json:"published_on" bson:"published_on" dynamodbav:"published_on"`
+	Name 		  string 					`json:"name,omitempty" bson:"name,omitempty" dynamodbav:"name,omitempty"`
+	Version       string                    `json:"version,omitempty" bson:"version,omitempty" dynamodbav:"version,omitempty"`
+	Protocols     []string                  `json:"protocols,omitempty" bson:"protocols,omitempty" dynamodbav:"protocols,omitempty"`
+	Platforms     []*terrarium.PlatformItem `json:"platforms,omitempty" bson:"platforms,omitempty" dynamodbav:"platforms,omitempty"`
+	Description   string                    `json:"description,omitempty" bson:"description,omitempty" dynamodbav:"description,omitempty"`
+	SourceRepoUrl string                    `json:"source_repo_url,omitempty" bson:"source_repo_url,omitempty" dynamodbav:"source_repo_url,omitempty"`
+	Maturity      string                    `json:"maturity,omitempty" bson:"maturity,omitempty" dynamodbav:"maturity,omitempty"`
+	CreatedOn     string                    `json:"created_on,omitempty" bson:"created_on,omitempty" dynamodbav:"created_on"`
+	ModifiedOn    string                    `json:"modified_on,omitempty" bson:"modified_on,omitempty" dynamodbav:"modified_on,omitempty"`
+	PublishedOn   string                    `json:"published_on,omitempty" bson:"published_on,omitempty" dynamodbav:"published_on,omitempty"`
 }
 
 // RegisterWithServer Registers VersionManagerService with grpc server

--- a/internal/provider/services/version_manager/version_manager.go
+++ b/internal/provider/services/version_manager/version_manager.go
@@ -57,7 +57,7 @@ type VersionManagerService struct {
 }
 
 type Provider struct {
-	Name 		  string 					`json:"name,omitempty" bson:"name,omitempty" dynamodbav:"name,omitempty"`
+	Name          string                    `json:"name,omitempty" bson:"name,omitempty" dynamodbav:"name,omitempty"`
 	Version       string                    `json:"version,omitempty" bson:"version,omitempty" dynamodbav:"version,omitempty"`
 	Protocols     []string                  `json:"protocols,omitempty" bson:"protocols,omitempty" dynamodbav:"protocols,omitempty"`
 	Platforms     []*terrarium.PlatformItem `json:"platforms,omitempty" bson:"platforms,omitempty" dynamodbav:"platforms,omitempty"`

--- a/internal/provider/services/version_manager/version_manager.go
+++ b/internal/provider/services/version_manager/version_manager.go
@@ -57,14 +57,14 @@ type VersionManagerService struct {
 }
 
 type Provider struct {
-	Name          string                    `json:"name,omitempty" bson:"name,omitempty" dynamodbav:"name,omitempty"`
-	Version       string                    `json:"version,omitempty" bson:"version,omitempty" dynamodbav:"version,omitempty"`
-	Protocols     []string                  `json:"protocols,omitempty" bson:"protocols,omitempty" dynamodbav:"protocols,omitempty"`
-	Platforms     []*terrarium.PlatformItem `json:"platforms,omitempty" bson:"platforms,omitempty" dynamodbav:"platforms,omitempty"`
-	Description   string                    `json:"description,omitempty" bson:"description,omitempty" dynamodbav:"description,omitempty"`
-	SourceRepoUrl string                    `json:"source_repo_url,omitempty" bson:"source_repo_url,omitempty" dynamodbav:"source_repo_url,omitempty"`
-	Maturity      string                    `json:"maturity,omitempty" bson:"maturity,omitempty" dynamodbav:"maturity,omitempty"`
-	CreatedOn     string                    `json:"created_on,omitempty" bson:"created_on,omitempty" dynamodbav:"created_on"`
+	Name          string                    `json:"name" bson:"name" dynamodbav:"name"`
+	Version       string                    `json:"version" bson:"version" dynamodbav:"version"`
+	Protocols     []string                  `json:"protocols" bson:"protocols" dynamodbav:"protocols"`
+	Platforms     []*terrarium.PlatformItem `json:"platforms" bson:"platforms" dynamodbav:"platforms"`
+	Description   string                    `json:"description" bson:"description" dynamodbav:"description"`
+	SourceRepoUrl string                    `json:"source_repo_url" bson:"source_repo_url" dynamodbav:"source_repo_url"`
+	Maturity      string                    `json:"maturity" bson:"maturity" dynamodbav:"maturity"`
+	CreatedOn     string                    `json:"created_on" bson:"created_on" dynamodbav:"created_on"`
 	ModifiedOn    string                    `json:"modified_on,omitempty" bson:"modified_on,omitempty" dynamodbav:"modified_on,omitempty"`
 	PublishedOn   string                    `json:"published_on,omitempty" bson:"published_on,omitempty" dynamodbav:"published_on,omitempty"`
 }


### PR DESCRIPTION
Problem:
- Found a small bug, On registration of providers, we are not yet publishing it, but although being empty, **published_on** field used to get added in the table as an attribute of an item having empty value, which should not happen until we publish it actually.
- Same for **modified_on** too.

Solution:
- Added **omit_empty** in the Struct tags which would avoid the structs to be added as an attribute in the table when it's empty as they get omitted.