### PR TITLE
[CIEDEV-5181]: Send terrarium traces to Lightstep

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,11 @@ func newServiceResource(name string) *resource.Resource {
 		versionInfo = serviceVersion
 	}
 
+	if serviceName, found := os.LookupEnv("OTEL_SERVICE_NAME"); found {
+		log.Println("Warning: service name overriden by environment variable")
+		name = serviceName
+	}
+
 	resources := resource.NewWithAttributes(
 		semconv.SchemaURL,
 		semconv.ServiceNameKey.String(name),


### PR DESCRIPTION
# Description
This PR enhances the service name configuration for traces reported to Lightstep. The application now checks for the `OTEL_SERVICE_NAME` environment variable:

- If the variable is set, its value is used as the service name.
- If not set, the application defaults to the hardcoded service name.

This update ensures flexibility by allowing the service name to be dynamically configured through environment variables.

# Testing Details:

- build deployed to tsuboniwa: `v0.0.84-ciedev-5181.0`

![image](https://github.com/user-attachments/assets/eb673724-8f3c-4270-9f94-1ef47cdcfc75)
![image](https://github.com/user-attachments/assets/ea414f70-ce58-4395-9bf4-1d6ec9a38926)

