### PR TITLE
Keep Terraform Binary

### DIFF
--- a/containers/nginx-static-server/Dockerfile
+++ b/containers/nginx-static-server/Dockerfile
@@ -6,7 +6,10 @@ WORKDIR /usr/share/nginx/html
 # Download the OpenTofu binary zip file, clean up and reduce the size of the Docker image by removing unnecessary files after installing packages.
 RUN apt-get update && apt-get install -y curl && \
     mkdir -p opentofu/1.9.0 && \
-    curl -Ls -o opentofu/1.9.0/tofu_1.9.0_linux_amd64.zip https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_linux_amd64.zip && \
+    curl -Ls -o opentofu/1.9.0/tofu_1.9.0_linux_amd64.zip https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_linux_amd64.zip
+
+RUN mkdir -p terraform/1.4.7 && \
+    curl -o terraform/1.4.7/terraform_1.4.7_linux_amd64.zip https://releases.hashicorp.com/terraform/1.4.7/terraform_1.4.7_linux_amd64.zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Start the NGINX server


### PR DESCRIPTION
## About

- No immediate need to remove support for Terraform Binary

## Testing
![image](https://github.com/user-attachments/assets/a81e363e-1e27-400a-b611-4334b41aa51b)
